### PR TITLE
Audits 621 s3 broker iam policies

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -19,9 +19,9 @@ The AWS tests need to run with an IAM user, and for operators we use `aws-vault`
 
 Run the profile for each of the AWS GovCloud and E-W Commercial accounts:
 
-    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
+    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml --silence-deprecations=aws
     aws-vault exec cg-ew -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
-    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-iam/ -t aws:// 
+    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-iam/ -t aws:// --silence-deprecations=aws
     inspec exec ./SC
 
 Take note of any failures and correct them

--- a/audit/README.md
+++ b/audit/README.md
@@ -21,7 +21,8 @@ Run the profile for each of the AWS GovCloud and E-W Commercial accounts:
 
     aws-vault exec cg-govcloud -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml --silence-deprecations=aws
     aws-vault exec cg-ew -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
-    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-iam/ -t aws:// --silence-deprecations=aws
+    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-iam/ -t aws:// --silence-deprecations=all # takes 11 minutes
+    
     inspec exec ./SC
 
 Take note of any failures and correct them

--- a/audit/README.md
+++ b/audit/README.md
@@ -4,13 +4,25 @@ If you're a cloud.gov team member, set up `aws-vault` per our guidance at https:
 
 You'll also need Docker, as `bin/inspec` will run [Chef Inspec](https://www.inspec.io/docs/) using `docker-compose`
 
+# Set up
+
+```
+docker pull chef/inspec
+```
+
 # Run the InSpec profile
 
-Update `inputs.yml` with the values for the cloud.gov team. Then run the profile for each of the AWS GovCloud and E-W Commercial accounts:
+## AWS
 
-    aws-vault exec cloud-gov-govcloud -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
-    aws-vault exec cloud-gov-ew -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
+The AWS tests need to run with an IAM user, and for operators we use `aws-vault` to create short-lived access keys. I (Peter) use the vault profiles `cg-govcloud` and `cg-ew`, yours may differ.  
 
+
+Run the profile for each of the AWS GovCloud and E-W Commercial accounts:
+
+    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
+    aws-vault exec cg-ew -- bin/inspec exec ./aws-mfa/ -t aws:// --input-file inputs.yml
+    aws-vault exec cg-govcloud -- bin/inspec exec ./aws-iam/ -t aws:// 
+    inspec exec ./SC
 
 Take note of any failures and correct them
 

--- a/audit/SC/inspec.lock
+++ b/audit/SC/inspec.lock
@@ -1,8 +1,3 @@
 ---
 lockfile_version: 1
-depends:
-- name: inspec-aws
-  resolved_source:
-    url: https://github.com/inspec/inspec-aws/archive/master.tar.gz
-    sha256: 0466e0d34d4b8de4a4c5262749fcf970290f87262513670e598ab67e7b0031c1
-  version_constraints: []
+depends: []

--- a/audit/SC/inspec.yml
+++ b/audit/SC/inspec.yml
@@ -3,8 +3,3 @@ title: cloud.gov InSPEC SC controls profile
 maintainer: cloud.gov
 license: cc0
 version: 0.1.0
-supports:
-  - platform: aws
-depends:
-  - name: inspec-aws
-    url: https://github.com/inspec/inspec-aws/archive/master.tar.gz

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -3,13 +3,14 @@
 # aip.where(policy_name: /cg-s3.*/).
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-aip = aws_iam_policies.where(policy_name: /^cg-s3-0/)
+s3_iam_pattern='^cg-s3-0'
+
+aip = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
 control '1.0-s3-iams' do
     impact 1.0
     title 'Ensure s3 iams are only s3'
-    aip.entries.each do | policy_name |
-        policy_name = "cg-s3-000a0b6a-e9ca-46d5-9040-98710b153a67"
-        policy = aws_iam_policy(policy_name)
+    aip.entries.each do | policy|
+        policy = aws_iam_policy(policy.policy_name)
         describe policy do
             it { should have_statement(
                     Resource: [
@@ -26,4 +27,18 @@ control '1.0-s3-iams' do
             its('statement_count') { should cmp 2 }
         end
     end
+
+    s3_policy_count = aip.count
+
+    describe aws_iam_users.where(user_name: /#{s3_iam_pattern}/) do
+      its('count') { should cmp s3_policy_count }
+    end
+
+
+
 end
+
+
+s3_policy_count = aip.count
+
+# count of s3 users should match o

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -3,22 +3,12 @@
 # aip.where(policy_name: /cg-s3.*/).
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-class AwsIamPolicy
-  def resource_count
-    return false unless @policy_document
-    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document), { symbolize_names: true })
-    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
-    statements.collect{ |s| s[:Resource] }.count
-  end
-end
-
-
-aip = aws_iam_policies.where(policy_name: /^cg-s3/)
+aip = aws_iam_policies.where(policy_name: /^cg-s3-0/)
 control '1.0-s3-iams' do
     impact 1.0
     title 'Ensure s3 iams are only s3'
     aip.entries.each do | policy_name |
-        policy_name = "cg-s3-17d833e5-af5d-4913-abae-332376bb01be"
+        policy_name = "cg-s3-000a0b6a-e9ca-46d5-9040-98710b153a67"
         policy = aws_iam_policy(policy_name)
         describe policy do
             it { should have_statement(
@@ -33,11 +23,7 @@ control '1.0-s3-iams' do
                     ]
                 )
             }
-        end
-        resource_count = policy.policy["Statement"].collect{ |s| s[:resource] }.count
-
-        describe resource_count do
-            it { should == 2}
+            its('statement_count') { should cmp 2 }
         end
     end
 end

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -1,8 +1,9 @@
 # preload AWS API calls
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-#s3_iam_pattern='cg-s3-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
-s3_iam_pattern='cg-s3-16[0-9a-fA-F]{7}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
+s3_iam_pattern='cg-s3-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
+# use next pattern for testing the snowflake
+#s3_iam_pattern='cg-s3-16[0-9a-fA-F]{7}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
 
 s3_policies = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/).entries
 s3_policy_count = s3_policies.count

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -1,13 +1,11 @@
 # preload AWS API calls
-# aip = aws_iam_policies
-# aip.where(policy_name: /cg-s3.*/).
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
 #s3_iam_pattern='^cg-s3-84'
 s3_iam_pattern='^cg-s3'
 
-aip = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
-s3_policy_count = aip.count
+s3_policies = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
+s3_policy_count = s3_policies.count
 control '1.0-s3-iams' do
     impact 1.0
     title 'Ensure s3 iams are only s3'
@@ -16,7 +14,7 @@ control '1.0-s3-iams' do
       its('count') { should cmp s3_policy_count }
     end
 
-    aip.entries.each do | p|
+    s3_policies.entries.each do | p|
         policy = aws_iam_policy(p.policy_name)
         describe policy do
             it { should be_attached_to_user(p.policy_name) }

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -33,12 +33,4 @@ control '1.0-s3-iams' do
     describe aws_iam_users.where(user_name: /#{s3_iam_pattern}/) do
       its('count') { should cmp s3_policy_count }
     end
-
-
-
 end
-
-
-s3_policy_count = aip.count
-
-# count of s3 users should match o

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -3,24 +3,32 @@
 # aip.where(policy_name: /cg-s3.*/).
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-s3_iam_pattern='^cg-s3-'
+#s3_iam_pattern='^cg-s3-84'
+s3_iam_pattern='^cg-s3'
 
 aip = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
+s3_policy_count = aip.count
 control '1.0-s3-iams' do
     impact 1.0
     title 'Ensure s3 iams are only s3'
-    aip.entries.each do | policy|
-        policy = aws_iam_policy(policy.policy_name)
+
+    describe aws_iam_users.where(user_name: /#{s3_iam_pattern}/) do
+      its('count') { should cmp s3_policy_count }
+    end
+
+    aip.entries.each do | p|
+        policy = aws_iam_policy(p.policy_name)
         describe policy do
+            it { should be_attached_to_user(p.policy_name) }
             it { should have_statement(
                     Resource: [
-                        /^arn:aws-us-gov:s3:::cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/
+                        /^arn:aws-us-gov:s3:::(staging-)?cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/
                     ]
                 )
             }
             it { should have_statement(
                     Resource: [
-                        /^arn:aws-us-gov:s3:::cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/\*$/
+                        /^arn:aws-us-gov:s3:::(staging-)?cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/\*$/
                     ]
                 )
             }
@@ -28,9 +36,4 @@ control '1.0-s3-iams' do
         end
     end
 
-    s3_policy_count = aip.count
-
-    describe aws_iam_users.where(user_name: /#{s3_iam_pattern}/) do
-      its('count') { should cmp s3_policy_count }
-    end
 end

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -1,0 +1,43 @@
+# preload AWS API calls
+# aip = aws_iam_policies
+# aip.where(policy_name: /cg-s3.*/).
+# notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
+
+class AwsIamPolicy
+  def resource_count
+    return false unless @policy_document
+    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
+    statements.collect{ |s| s[:Resource] }.count
+  end
+end
+
+
+aip = aws_iam_policies.where(policy_name: /^cg-s3/)
+control '1.0-s3-iams' do
+    impact 1.0
+    title 'Ensure s3 iams are only s3'
+    aip.entries.each do | policy_name |
+        policy_name = "cg-s3-17d833e5-af5d-4913-abae-332376bb01be"
+        policy = aws_iam_policy(policy_name)
+        describe policy do
+            it { should have_statement(
+                    Resource: [
+                        /^arn:aws-us-gov:s3:::cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/
+                    ]
+                )
+            }
+            it { should have_statement(
+                    Resource: [
+                        /^arn:aws-us-gov:s3:::cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/\*$/
+                    ]
+                )
+            }
+        end
+        resource_count = policy.policy["Statement"].collect{ |s| s[:resource] }.count
+
+        describe resource_count do
+            it { should == 2}
+        end
+    end
+end

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -3,7 +3,7 @@
 # aip.where(policy_name: /cg-s3.*/).
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-s3_iam_pattern='^cg-s3-0'
+s3_iam_pattern='^cg-s3-'
 
 aip = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
 control '1.0-s3-iams' do

--- a/audit/aws-iam/controls/roles_policies.rb
+++ b/audit/aws-iam/controls/roles_policies.rb
@@ -1,21 +1,46 @@
 # preload AWS API calls
 # notcgs3=aip.where{ policy_name !~ /^cg-s3/ && arn !~ /::aws:policy/ }
 
-#s3_iam_pattern='^cg-s3-84'
+#s3_iam_pattern='^cg-s3-1'
 s3_iam_pattern='^cg-s3'
 
-s3_policies = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/)
+s3_policies = aws_iam_policies.where(policy_name: /#{s3_iam_pattern}/).entries
+
+snowflake_iam_policy = "cg-s3-16709a09-0eca-4597-bbf5-b1df98e41cae" 
+s3_policies.delete_if{ |p| p.policy_name == snowflake_iam_policy }
+
 s3_policy_count = s3_policies.count
-control '1.0-s3-iams' do
+control 'X S3 IAM policies match S3 IAM users' do
     impact 1.0
     title 'Ensure s3 iams are only s3'
 
     describe aws_iam_users.where(user_name: /#{s3_iam_pattern}/) do
       its('count') { should cmp s3_policy_count }
     end
+end
 
-    s3_policies.entries.each do | p|
-        policy = aws_iam_policy(p.policy_name)
+control "Ensure Snowflake policy is well-formed" do
+    snowflake = aws_iam_policy(snowflake_iam_policy)
+    describe snowflake do 
+        it { should have_statement(
+                Resource: [
+                    /^arn:aws-us-gov:s3:::(staging-)?cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/
+                ]
+            )
+        }
+        it { should have_statement(
+                Resource: [
+                    /^arn:aws-us-gov:s3:::(staging-)?cg-[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/\*$/
+                ]
+            )
+        }
+        its('statement_count') { should cmp 3 }
+    end
+end
+
+s3_policies.each do | p|
+    policy = aws_iam_policy(p.policy_name)
+    control "Ensure S3 policy #{policy} is well-formed" do
         describe policy do
             it { should be_attached_to_user(p.policy_name) }
             it { should have_statement(
@@ -33,5 +58,4 @@ control '1.0-s3-iams' do
             its('statement_count') { should cmp 2 }
         end
     end
-
 end

--- a/audit/aws-iam/inspec.lock
+++ b/audit/aws-iam/inspec.lock
@@ -1,0 +1,3 @@
+---
+lockfile_version: 1
+depends: []

--- a/audit/aws-iam/inspec.yml
+++ b/audit/aws-iam/inspec.yml
@@ -1,0 +1,10 @@
+name: IAM
+title: Test AWS roles and policies
+version: 0.1.0
+license: CC0
+summary: Replace manual role/policy assessment
+supports:
+  - platform: aws
+depends:
+  - name: inspec-aws
+    url: https://github.com/inspec/inspec-aws/archive/master.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix the README so it provides correct guidance for all the tests
- Add an `aws-iam` control to test AWS IAM policies

## Security considerations

Inspec tests reveal some naming conventions that are also discernible from code for `aws-broker`, this does not pose a threat
