### PR TITLE
Add John Mullen to AWS audit inputs

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -7,6 +7,7 @@ admins:
   - carlo.costino
   - chris.mcgowan
   - jeff.fredrickson
+  - john.mullen
   - mark.headd
   - rebecca.goodman
   - steve.greenberg


### PR DESCRIPTION
This changeset adds John Mullen to the cloud.gov AWS audit checks.

## Changes proposed in this pull request:

- Add John's AWS username to our list

## Security considerations

- Keeps our audit checks of AWS accounts up to date