### PR TITLE
Add Kwadwo to IAM audit file

### DIFF
--- a/audit/aws-mfa/controls/mfa.rb
+++ b/audit/aws-mfa/controls/mfa.rb
@@ -30,7 +30,7 @@ control '1.1-count-console-users' do
     console_users = all_users.where(has_console_password?: true)
 
     describe console_users.usernames.length do
-        it { should be == 12 }
+        it { should be == 13 }
     end
 end
 

--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -8,6 +8,7 @@ admins:
   - chris.mcgowan
   - jeff.fredrickson
   - john.mullen
+  - kwadwo.korang
   - mark.headd
   - rebecca.goodman
   - steve.greenberg


### PR DESCRIPTION
This changset adds @kwadwok15's account to our IAM audit file.

## Changes proposed in this pull request:
- Adds Kwadwo's AWS account to the audit file

## Security considerations
- Helps keep our system security by auditing new account