### PR TITLE
Offboard John Mullen

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -7,7 +7,6 @@ admins:
   - carlo.costino
   - chris.mcgowan
   - jeff.fredrickson
-  - john.mullen
   - mark.headd
   - rebecca.goodman
   - steve.greenberg


### PR DESCRIPTION
Removing John Mullen as he has been offboarded from the team

## Changes proposed in this pull request:
- Remove John Mullen's AWS account name

## Security considerations:
- None; keeps our system secure by having folks no longer on the team not listed