### PR TITLE
Remove Steve and Jeff from our MFA audits

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -6,9 +6,7 @@ admins:
   - ben.berry
   - carlo.costino
   - chris.mcgowan
-  - jeff.fredrickson
   - kwadwo.korang
   - mark.headd
   - rebecca.goodman
-  - steve.greenberg
   - van.nguyen


### PR DESCRIPTION
Steve and Jeff have been offboarded from the team and their AWS accounts removed.

## Changes proposed in this pull request:
- Removed Steve and Jeff's usernames from the input list

## Security considerations:
- Helps keep our system secure and in check with compliance requirements.