### PR TITLE
Remove Ron Williams from audit check

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -1,5 +1,4 @@
 non-admins:
-  - ron.williams
   - peter.burkholder
 admins:
   - andrew.burnes


### PR DESCRIPTION
Ron is being offboarded from the team.

## Changes proposed in this pull request:
- Removes Ron from audit checks as his AWS accounts have been removed.

## Security considerations:
- Helps the program remain complaint with up-to-date audit checks