### PR TITLE
Update team member information

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -1,11 +1,11 @@
 non-admins:
   - peter.burkholder
+  - lindsay.young
 admins:
   - andrew.burnes
   - ben.berry
   - carlo.costino
   - chris.mcgowan
-  - haywood.wells
   - mark.headd
   - rebecca.goodman
   - van.nguyen


### PR DESCRIPTION
This changeset updates team member information with team members who have onboarded and offboarded recently:

## Changes proposed in this pull request:
- Removes Haywood Wells (platform operator)
- Adds Lindsay Young (system owner)

## Security considerations:
- Helps us maintain our security compliance posture by checking team member AWS accounts