### PR TITLE
Offboard Becca Goodman

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -7,5 +7,4 @@ admins:
   - carlo.costino
   - chris.mcgowan
   - mark.headd
-  - rebecca.goodman
   - van.nguyen


### PR DESCRIPTION
Remove Becca Goodman as a part of offboarding.  AWS accounts have already been removed.

## Changes proposed in this pull request:
- Removes Becca from the list of accounts to check

## Security considerations:
- Helps our team maintain compliance