### PR TITLE
Onboard David Anderson

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -1,6 +1,7 @@
 non-admins:
   - peter.burkholder
   - lindsay.young
+  - david.anderson
 admins:
   - andrew.burnes
   - ben.berry


### PR DESCRIPTION
This change adds David Anderson to our AWS MFA audit file.  At the start, he'll be read only, and once his trainings are complete, we'll shift to full admin rights.

## Changes proposed in this pull request:
- Adds David Anderson to non-admins to start

## Security considerations:
- Helps us maintain proper auditing of our AWS access