### PR TITLE
Make David Anderson an admin

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -1,12 +1,12 @@
 non-admins:
   - peter.burkholder
   - lindsay.young
-  - david.anderson
 admins:
   - andrew.burnes
   - ben.berry
   - carlo.costino
   - chris.mcgowan
+  - david.anderson
   - mark.headd
   - rian.bogle
   - van.nguyen


### PR DESCRIPTION
Now that David has completed his training, his AWS accounts should be tracked as admin accounts.

## Changes proposed in this pull request:
- Modifies David's account to be an admin

## Security considerations:
- Helps us maintain our compliance requirements