### PR TITLE
Clean up user audit list

### DIFF
--- a/audit/inputs.yml
+++ b/audit/inputs.yml
@@ -1,13 +1,15 @@
 non-admins:
   - peter.burkholder
   - chiaka.opara
+  - arsalan.haider
 admins:
   - andrew.burnes
-  - ben.berry
   - chris.mcgowan
+  - chris.weibel
   - david.anderson
-  - mark.headd
-  - rian.bogle
-  - van.nguyen
-  - robert.gottlieb
+  - dorothy.tamasang
+  - james.hochadel
+  - jason.gambino
   - mark.boyd
+  - robert.gottlieb
+  - van.nguyen


### PR DESCRIPTION
Related: https://github.com/cloud-gov/product/issues/2490

## Changes proposed in this pull request:

- @pburkholder it's unclear to me if this is in use, since it was so out of date; can you give any insight?
- Add Chris M and align list with current staff

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Possibly affects compliance auditing of IaaS admins.
